### PR TITLE
Use ReplaySubject instead of Subject when loading cached collections

### DIFF
--- a/src/data-connector.class.ts
+++ b/src/data-connector.class.ts
@@ -286,11 +286,12 @@ export class DataConnector {
      * Get the observable associated to the collection from the store
      * @param {string} type Endpoint name
      * @param {FilterData} filter Filter object
+     * @param useCache
      * @returns {Observable<DataCollection>} The observable associated to the collection
      */
-    private getCollectionObservableInStore(type:string, filter:FilterData):Observable<DataCollection> {
+    private getCollectionObservableInStore(type:string, filter:FilterData, useCache = false):Observable<DataCollection> {
         if (this.collectionsLiveStore[type]) {
-            return this.collectionsLiveStore[type].getCollectionSubject(filter);
+            return this.collectionsLiveStore[type].getCollectionSubject(filter, useCache);
         }
 
         return null;
@@ -429,15 +430,16 @@ export class DataConnector {
      * Get observable associated to the collection from the store. If store is undefined, create it
      * @param {string} type Endpoint name
      * @param {FilterData} filter Filter object
+     * @param useCache
      * @returns {Observable<DataCollection>} Observable associated to the collection
      */
-    private getCollectionObservable(type:string, filter:FilterData):Subject<DataCollection> {
+    private getCollectionObservable(type:string, filter:FilterData, useCache = false):Subject<DataCollection> {
 
         if (!this.collectionsLiveStore[type]) {
             this.collectionsLiveStore[type] = new CollectionStore();
         }
 
-        return this.collectionsLiveStore[type].getCollectionSubject(filter);
+        return this.collectionsLiveStore[type].getCollectionSubject(filter, useCache);
     }
 
     /**
@@ -810,9 +812,10 @@ export class DataConnector {
      * @returns {Observable<DataCollection>} Observable associated to this collection
      */
     loadCollection(type:string, filter:FilterData = {}):Observable<DataCollection> {
+        const useCache = this.useCache(type);
 
-        if (this.useCache(type)) {
-            let obs:Observable<DataCollection> = this.getCollectionObservableInStore(type, filter);
+        if (useCache) {
+            let obs:Observable<DataCollection> = this.getCollectionObservableInStore(type, filter, useCache);
 
             if (obs) {
                 return obs;
@@ -827,7 +830,7 @@ export class DataConnector {
         let embeddings: {[key: string]: string} = this.getEmbeddings(type);
 
         if (selectedInterface) {
-            let collectionSubject:Subject<DataCollection> = this.getCollectionObservable(type, filter);
+            let collectionSubject:Subject<DataCollection> = this.getCollectionObservable(type, filter, useCache);
             let collection:CollectionDataSet|Observable<CollectionDataSet>;
 
             let checkResponse:Function = () => {

--- a/src/stores/collection-store.class.ts
+++ b/src/stores/collection-store.class.ts
@@ -3,7 +3,7 @@ import {DataCollection} from "../data-structures/data-collection.class";
 import * as ObjectHash from "object-hash";
 import {DataEntity} from "../data-structures/data-entity.class";
 import {FilterData} from "../types";
-import {Subject} from "rxjs";
+import {ReplaySubject, Subject} from "rxjs";
 
 /**
  * Collection store: where the collections and the collection observables are stored for an endpoint
@@ -193,16 +193,23 @@ export class CollectionStore {
     /**
      * Returns the observable associated to the specified filter
      * @param {FilterData} filter Filter object
+     * @param useCache
      * @returns {Observable<DataCollection>} The observable associated to the filter object
      */
-    getCollectionSubject(filter:FilterData):Subject<DataCollection> {
+    getCollectionSubject(filter:FilterData, useCache = false):Subject<DataCollection> {
 
         let hash:string = ObjectHash(filter);
 
         if (this.collectionObservables[hash]) {
             return this.collectionObservables[hash];
         } else {
-            let subject:Subject<DataCollection> = new Subject<DataCollection>();
+            let subject:Subject<DataCollection>;
+
+            if (useCache) {
+                subject = new ReplaySubject<DataCollection>();
+            } else {
+                subject = new Subject<DataCollection>();
+            }
             this.collectionObservables[hash] = subject;
             return subject;
         }


### PR DESCRIPTION
Passage de la notion de `cached` pour utiliser un `ReplaySubject` dans ce cas là.