### PR TITLE
Fix wrong collection observable triggered by refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus-connect",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "author": "tralalere",
   "license": "ISC",
   "bugs": {

--- a/projects/octopus-connect/package.json
+++ b/projects/octopus-connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "octopus-connect",
-    "version": "16.0.0",
+    "version": "16.0.1",
     "peerDependencies": {
         "@angular/common": "^16.1.0",
         "@angular/core": "^16.1.0",

--- a/projects/octopus-connect/src/lib/models/stores/collection-store.class.ts
+++ b/projects/octopus-connect/src/lib/models/stores/collection-store.class.ts
@@ -98,7 +98,7 @@ export class CollectionStore {
         const filterKeys: string[] = Object.keys(this.collectionObservables);
 
         filterKeys.forEach((hash: string) => {
-            if (this.filterMatching(filter, this.filters[hash])) {
+            if (this.filters[hash] && this.collections[hash] && this.filterMatching(filter, this.filters[hash])) {
                 this.collectionObservables[hash].next(this.collections[hash]);
             }
         });
@@ -166,6 +166,10 @@ export class CollectionStore {
      * @returns {boolean}
      */
     filterMatching(filter1: FilterData = {}, filter2: FilterData = {}): boolean {
+
+        if (!filter1 || !filter2) {
+            return false;
+        }
 
         // must have the same keys
         const filter1Keys: string[] = Object.keys(filter1);


### PR DESCRIPTION
- Ajoute des vérifications lors d'un refresh d'une collection
  - `this.collectionObservables` est rempli au lancement de la requête alors que `this.filters` et `this.collections` sont remplis après qu'on reçoit la réponse de la requête
  - on vérifie l'existence de données pour le hash du filtre dans les 3 tableaux pour être sûr qu'on n'opère pas sur des données non définies (le cas se présente quand plusieurs requêtes sont réalisées sur le même endpoint avec des filtres différents)
  - corrige aussi la fonction `filterMatching` qui retournait `true` dans le cas où l'un des objets de filtre est vide et l'autre est `undefined` ou `null`